### PR TITLE
Fix KPI table style to avoid KeyError

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -278,11 +278,15 @@ with tab1:
 
             def highlight(row):
                 color = color_map.get(row["Status"], "white")
-                return [f"background-color: {color}"] * 2
+                return [f"background-color: {color}"] * len(row)
 
             st.markdown(f"**{loc}**")
-            styled = df_loc[["KPI", "Value"]].style.apply(highlight, axis=1)
-            st.dataframe(styled, hide_index=True, use_container_width=True)
+            styled = (
+                df_loc.style.apply(highlight, axis=1)
+                .hide_index()
+                .hide_columns(["Status"])
+            )
+            st.dataframe(styled, use_container_width=True)
 
         # Targets reference table
         target_rows = []


### PR DESCRIPTION
## Summary
- correct KPI table styling in streamlit_app to prevent `KeyError: 'Status'`

## Testing
- `python -m py_compile streamlit_app.py`
- `streamlit run --headless streamlit_app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685af547d1188323a80a410d08f0e2f9